### PR TITLE
ios: ability to use a custom image name for splash screen, allowing re-use of LaunchScreen.xib

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ npm install react-native-smart-splash-screen --save
 
 * In your project, Look for Header Search Paths and make sure it contains $(SRCROOT)/../node_modules/react-native-smart-splash-screen/ios/RCTSplashScreen/RCTSplashScreen
 
-* delete your project's LaunchScreen.xib
-
-* Dray SplashScreenResource folder to your project *if you want change image, replace splash.png*
+* Click on LaunchScreen.xib > right utilities panel "Attributes Inspector" > get the name of the image used (labeled "Image") (PS: you should follow the Apple XCode guide to set the LaunchScreen if there's not Image field set)
 
 * In AppDelegate.m
 
@@ -45,7 +43,7 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                            initialProperties:nil
                                                launchOptions:launchOptions];
 
-[RCTSplashScreen open:rootView]; //activate splashscreen
+[RCTSplashScreen open:rootView withImageNamed:@"image-name-from-LaunchScreen.xib"]; // activate splashscreen, imagename from LaunchScreen.xib
 
 rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 

--- a/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.h
+++ b/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.h
@@ -10,5 +10,6 @@ typedef NS_ENUM(NSInteger, RCTCameraAspect) {
 };
 
 + (void)open:(RCTRootView *)v;
++ (void)open:(RCTRootView *)v withImageNamed:(NSString *)imgName;
 
 @end

--- a/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.m
+++ b/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.m
@@ -11,15 +11,26 @@ static RCTRootView *rootView = nil;
 
 RCT_EXPORT_MODULE(SplashScreen)
 
+
 + (void)open:(RCTRootView *)v {
+    [RCTSplashScreen open:v withImageNamed:@"splash"];
+}
+
+
++ (void)open:(RCTRootView *)v withImageNamed:(NSString *)imageName {
     rootView = v;
+
     UIImageView *view = [[UIImageView alloc]initWithFrame:[UIScreen mainScreen].bounds];
-    view.image = [UIImage imageNamed:@"splash"];
+    
+    view.image = [UIImage imageNamed:imageName];
     
     [[NSNotificationCenter defaultCenter] removeObserver:rootView  name:RCTContentDidAppearNotification object:rootView];
     
     [rootView setLoadingView:view];
 }
+
+
+
 
 RCT_EXPORT_METHOD(close:(NSInteger *)animationType
                    duration:(NSInteger)duration


### PR DESCRIPTION
a couple of benefits:
- keeping the LaunchScreen.xib allows the native app setup to have a launch screen
- ability to re-use an xcassets app in both LaunchScreen.xib and this react-native componet