### PR TITLE
Update iOS headers for React Native 0.40

### DIFF
--- a/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.h
+++ b/ios/RCTSplashScreen/RCTSplashScreen/RCTSplashScreen.h
@@ -1,5 +1,5 @@
-#import "RCTBridgeModule.h"
-#import "RCTRootView.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTRootView.h>
 
 @interface RCTSplashScreen : NSObject <RCTBridgeModule>
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/react-native-component/react-native-smart-splash-screen/issues"
   },
   "homepage": "https://github.com/react-native-component/react-native-smart-splash-screen#readme",
-  "dependencies": {
+  "peerDependencies": {
     "react-native": "^0.40.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/react-native-component/react-native-smart-splash-screen/issues"
   },
-  "homepage": "https://github.com/react-native-component/react-native-smart-splash-screen#readme"
+  "homepage": "https://github.com/react-native-component/react-native-smart-splash-screen#readme",
+  "dependencies": {
+    "react-native": "^0.40.0"
+  }
 }


### PR DESCRIPTION
- Also add explicit React-Native version (^0.40) peer dependency to package.json

See https://github.com/facebook/react-native/releases/tag/v0.40.0 for more information on the breaking changes for iOS React Native header imports. Note that this will likely break compatibility with React Native <0.40, which certainly could be problematic for some users. It's up to the maintainer - if <0.40 support is more important, than a separate branch could be made for 0.40+; if keeping up-to-date with React Native's latest is more important, then a note could be added to the README to point <0.40 users to a specific commit/branch before introducing these 0.40 fixes. Publishing releases might also be helpful here, with clear notes on which React Native versions are supported for each release. Thoughts?