### PR TITLE
Fixed crash when dialog.dismiss()

### DIFF
--- a/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreen.java
+++ b/android/src/main/java/com/reactnativecomponent/splashscreen/RCTSplashScreen.java
@@ -122,9 +122,11 @@ public class RCTSplashScreen {
                             view.post(new Runnable() {
                                 @Override
                                 public void run() {
-                                    dialog.dismiss();
-                                    dialog = null;
-                                    imageView = null;
+                                    if (dialog != null && dialog.isShowing()) {
+                                        dialog.dismiss();
+                                        dialog = null;
+                                        imageView = null;
+                                    }
                                 }
                             });
                         }


### PR DESCRIPTION
java.lang.IllegalArgumentException: 
  at android.view.WindowManagerGlobal.findViewLocked (WindowManagerGlobal.java:485)
  at android.view.WindowManagerGlobal.removeView (WindowManagerGlobal.java:394)
  at android.view.WindowManagerImpl.removeViewImmediate (WindowManagerImpl.java:124)
  at android.app.Dialog.dismissDialog (Dialog.java:375)
  at android.app.Dialog.dismiss (Dialog.java:358)
  at com.reactnativecomponent.splashscreen.RCTSplashScreen$2$1$1.run (RCTSplashScreen.java:125)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:193)
  at android.app.ActivityThread.main (ActivityThread.java:6912)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:860)