### PR TITLE
Become compatible with React Native v0.59

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 23)
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +24,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "23.4.0")}'
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
React Native v0.59 uses a new version of the Android SDK that is incompatible with the one in this library, producing build failures. Using the `rootProject` setting means this library will automatically work with a broad range of React Native versions, so this shouldn't be a breaking change.

This would replace the need for #67, #64, or #35, without the need to publish a major version bump.